### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #localizer
 
-> Localized and configureable async and sync `requre.resolve()` implementation.
+> Localized and configurable async and sync `requre.resolve()` implementation.
 
 ## Installation
 


### PR DESCRIPTION
@AndreasMadsen, I've corrected a typographical error in the documentation of the [localizer](https://github.com/AndreasMadsen/localizer) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
